### PR TITLE
Persist meals and diet plans in Netlify database

### DIFF
--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -1,5 +1,8 @@
 const { getStore } = require('@netlify/blobs');
+const { neon } = require('@netlify/neon');
 const crypto = require('crypto');
+const mealsSeed = require('../../src/data/meals.json');
+const dietPlansSeed = require('../../src/data/dietPlans.json');
 
 const OPENAI_REQUEST_TIMEOUT_MS = Number(process.env.OPENAI_REQUEST_TIMEOUT_MS || 20000);
 const OPENAI_ANALYSIS_TIMEOUT_MS = Number(
@@ -119,6 +122,13 @@ const NUTRIENT_FIELDS = [
   'vitamin_c',
   'vitamin_a'
 ];
+
+function generateId() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
 
 const DEFAULT_SUGGESTION_LIMIT = 7;
 const OPENAI_SUGGESTION_MODEL = process.env.OPENAI_SUGGESTION_MODEL || 'gpt-4o-mini';
@@ -314,7 +324,7 @@ const MOCK_RESPONSE = {
 function normalizeIngredient(ingredient, index = 0) {
   const safe = typeof ingredient === 'object' && ingredient !== null ? { ...ingredient } : {};
   const normalized = {
-    id: typeof safe.id === 'string' && safe.id.length > 0 ? safe.id : `ingredient_${Date.now()}_${index}`,
+    id: typeof safe.id === 'string' && safe.id.length > 0 ? safe.id : `ingredient_${generateId()}`,
     name:
       typeof safe.name === 'string' && safe.name.length > 0
         ? safe.name
@@ -1081,6 +1091,321 @@ async function analyzeWithOpenAI({ imageDataUrl }) {
   return cacheAnalysis(cacheKey, ensureNumbers(parsed));
 }
 
+const getSqlClient = (() => {
+  let client = null;
+  return () => {
+    if (!client) {
+      const connectionString =
+        process.env.NETLIFY_DATABASE_URL || process.env.NETLIFY_DATABASE_URL_UNPOOLED || undefined;
+      client = connectionString ? neon(connectionString) : neon();
+    }
+    return client;
+  };
+})();
+
+let schemaInitializationPromise = null;
+
+function normalizeIngredientsList(ingredients = []) {
+  if (!Array.isArray(ingredients) || ingredients.length === 0) {
+    return [];
+  }
+
+  return ingredients.map((ingredient, index) => normalizeIngredient(ingredient, index));
+}
+
+function normalizeMealForStorage(meal, index = 0) {
+  const safe = typeof meal === 'object' && meal !== null ? { ...meal } : {};
+  const createdSource = safe.created_date || safe.createdDate || safe.meal_date;
+  const createdDate = createdSource ? new Date(createdSource) : new Date();
+  const createdIso = Number.isNaN(createdDate.getTime()) ? new Date().toISOString() : createdDate.toISOString();
+
+  const normalizedIngredients = normalizeIngredientsList(safe.ingredients);
+  const totals = normalizedIngredients.length > 0 ? sumNutrients(normalizedIngredients) : null;
+
+  const normalized = {
+    id: typeof safe.id === 'string' && safe.id.length > 0 ? safe.id : `meal_${generateId()}`,
+    meal_name: typeof safe.meal_name === 'string' ? safe.meal_name : '',
+    meal_type: typeof safe.meal_type === 'string' ? safe.meal_type : 'lunch',
+    analysis_notes: typeof safe.analysis_notes === 'string' ? safe.analysis_notes : '',
+    notes: typeof safe.notes === 'string' ? safe.notes : '',
+    photo_url: typeof safe.photo_url === 'string' ? safe.photo_url : '',
+    created_date: createdIso,
+    ingredients: normalizedIngredients
+  };
+
+  NUTRIENT_FIELDS.forEach((field) => {
+    const provided = Number(safe[field]);
+    normalized[field] = Number.isFinite(provided)
+      ? provided
+      : totals
+        ? totals[field]
+        : 0;
+  });
+
+  if (totals) {
+    NUTRIENT_FIELDS.forEach((field) => {
+      normalized[field] = totals[field];
+    });
+  }
+
+  if (normalized.ingredients.length === 0) {
+    normalized.ingredients = [
+      normalizeIngredient(
+        {
+          name: normalized.meal_name || 'Meal serving',
+          unit: 'serving',
+          amount: 1,
+          ...NUTRIENT_FIELDS.reduce(
+            (acc, field) => ({
+              ...acc,
+              [field]: Number.isFinite(Number(normalized[field])) ? Number(normalized[field]) : 0
+            }),
+            {}
+          )
+        },
+        0
+      )
+    ];
+  }
+
+  return normalized;
+}
+
+function deserializeMealRow(row, index = 0) {
+  if (!row) {
+    return null;
+  }
+
+  const payload = typeof row.data === 'object' && row.data !== null ? { ...row.data } : {};
+  const createdValue = row.created_date instanceof Date
+    ? row.created_date.toISOString()
+    : row.created_date || payload.created_date;
+
+  return normalizeMealForStorage(
+    {
+      ...payload,
+      id: row.id,
+      created_date: createdValue
+    },
+    index
+  );
+}
+
+function normalizeMacroTargetsForStorage(targets = {}) {
+  if (!targets || typeof targets !== 'object') {
+    return {};
+  }
+
+  return Object.entries(targets).reduce((acc, [key, value]) => {
+    const normalizedKey = typeof key === 'string' && key.length > 0 ? key.toLowerCase() : key;
+    const numericValue = Number(value);
+    acc[normalizedKey] = Number.isFinite(numericValue) ? Math.round(numericValue) : 0;
+    return acc;
+  }, {});
+}
+
+function normalizeMealGuidanceForStorage(entries = []) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries
+    .map((entry, index) => {
+      const safe = typeof entry === 'object' && entry !== null ? entry : {};
+      const name = typeof safe.name === 'string' && safe.name.length > 0
+        ? safe.name
+        : `Meal ${index + 1}`;
+      const description = typeof safe.description === 'string' ? safe.description : '';
+
+      if (!name && !description) {
+        return null;
+      }
+
+      return { name, description };
+    })
+    .filter(Boolean);
+}
+
+function normalizeDietPlanForStorage(plan, index = 0) {
+  const safe = typeof plan === 'object' && plan !== null ? { ...plan } : {};
+  const createdSource = safe.created_at || safe.createdAt;
+  const updatedSource = safe.updated_at || safe.updatedAt;
+  const createdAt = createdSource ? new Date(createdSource) : new Date();
+  const updatedAt = updatedSource ? new Date(updatedSource) : new Date();
+
+  const normalizedTargets = normalizeMacroTargetsForStorage(safe.macroTargets || safe.targets);
+  const hasTargets = Object.keys(normalizedTargets).length > 0;
+
+  const normalized = {
+    id:
+      typeof safe.id === 'string' && safe.id.length > 0
+        ? safe.id
+        : `diet_plan_${generateId()}`,
+    name:
+      typeof safe.name === 'string' && safe.name.length > 0
+        ? safe.name
+        : `Diet Plan ${index + 1}`,
+    goal: typeof safe.goal === 'string' ? safe.goal : '',
+    description: typeof safe.description === 'string' ? safe.description : '',
+    macroTargets: hasTargets
+      ? normalizedTargets
+      : {
+          calories: 2000,
+          protein: 100,
+          carbs: 220,
+          fat: 70,
+        },
+    hydrationTarget: Number.isFinite(Number(safe.hydrationTarget))
+      ? Number(safe.hydrationTarget)
+      : 8,
+    focus: Array.isArray(safe.focus) ? safe.focus.map((item) => String(item)) : [],
+    mealGuidance: normalizeMealGuidanceForStorage(safe.mealGuidance),
+    tips: Array.isArray(safe.tips) ? safe.tips.map((item) => String(item)) : [],
+    created_at: Number.isNaN(createdAt.getTime()) ? new Date().toISOString() : createdAt.toISOString(),
+    updated_at: Number.isNaN(updatedAt.getTime()) ? new Date().toISOString() : updatedAt.toISOString(),
+    isActive: Boolean(safe.isActive),
+    source:
+      typeof safe.source === 'string' && safe.source.length > 0
+        ? safe.source
+        : 'template',
+  };
+
+  return normalized;
+}
+
+function deserializeDietPlanRow(row, index = 0) {
+  if (!row) {
+    return null;
+  }
+
+  const payload = typeof row.data === 'object' && row.data !== null ? { ...row.data } : {};
+  const createdAtValue = row.created_at instanceof Date
+    ? row.created_at.toISOString()
+    : row.created_at || payload.created_at;
+  const updatedAtValue = row.updated_at instanceof Date
+    ? row.updated_at.toISOString()
+    : row.updated_at || payload.updated_at;
+  const isActive = typeof row.is_active === 'boolean' ? row.is_active : Boolean(payload.isActive);
+
+  return normalizeDietPlanForStorage(
+    {
+      ...payload,
+      id: row.id,
+      created_at: createdAtValue,
+      updated_at: updatedAtValue,
+      isActive
+    },
+    index
+  );
+}
+
+async function initializeDatabase() {
+  const sql = getSqlClient();
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meals (
+      id TEXT PRIMARY KEY,
+      created_date TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      data JSONB NOT NULL
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS diet_plans (
+      id TEXT PRIMARY KEY,
+      is_active BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      data JSONB NOT NULL
+    )
+  `;
+
+  const mealCountResult = await sql`SELECT COUNT(*)::int AS count FROM meals`;
+  const mealCount = Number(mealCountResult?.[0]?.count || 0);
+
+  if (mealCount === 0 && Array.isArray(mealsSeed)) {
+    for (let index = 0; index < mealsSeed.length; index += 1) {
+      const normalized = normalizeMealForStorage(mealsSeed[index], index);
+      await sql`
+        INSERT INTO meals (id, created_date, data)
+        VALUES (${normalized.id}, ${normalized.created_date}, ${sql.json(normalized)})
+        ON CONFLICT (id) DO NOTHING
+      `;
+    }
+  }
+
+  const planCountResult = await sql`SELECT COUNT(*)::int AS count FROM diet_plans`;
+  const planCount = Number(planCountResult?.[0]?.count || 0);
+
+  if (planCount === 0 && Array.isArray(dietPlansSeed)) {
+    const seededPlans = dietPlansSeed.map((plan, index) =>
+      normalizeDietPlanForStorage(
+        {
+          ...plan,
+          isActive: index === 0,
+          created_at: plan?.created_at || plan?.createdAt || new Date().toISOString(),
+          updated_at: plan?.updated_at || plan?.updatedAt || new Date().toISOString(),
+        },
+        index
+      )
+    );
+
+    if (!seededPlans.some((plan) => plan.isActive) && seededPlans.length > 0) {
+      seededPlans[0].isActive = true;
+    }
+
+    for (const plan of seededPlans) {
+      await sql`
+        INSERT INTO diet_plans (id, is_active, created_at, updated_at, data)
+        VALUES (${plan.id}, ${plan.isActive}, ${plan.created_at}, ${plan.updated_at}, ${sql.json(plan)})
+        ON CONFLICT (id) DO NOTHING
+      `;
+    }
+  }
+}
+
+async function ensureDatabase() {
+  if (!schemaInitializationPromise) {
+    schemaInitializationPromise = initializeDatabase().catch((error) => {
+      schemaInitializationPromise = null;
+      throw error;
+    });
+  }
+
+  return schemaInitializationPromise;
+}
+
+async function upsertMeal(sql, meal) {
+  await sql`
+    INSERT INTO meals (id, created_date, data)
+    VALUES (${meal.id}, ${meal.created_date}, ${sql.json(meal)})
+    ON CONFLICT (id) DO UPDATE
+      SET created_date = EXCLUDED.created_date,
+          data = EXCLUDED.data
+  `;
+}
+
+async function upsertDietPlan(sql, plan) {
+  await sql`
+    INSERT INTO diet_plans (id, is_active, created_at, updated_at, data)
+    VALUES (${plan.id}, ${plan.isActive}, ${plan.created_at}, ${plan.updated_at}, ${sql.json(plan)})
+    ON CONFLICT (id) DO UPDATE
+      SET is_active = EXCLUDED.is_active,
+          updated_at = EXCLUDED.updated_at,
+          data = EXCLUDED.data
+  `;
+
+  if (plan.isActive) {
+    await sql`
+      UPDATE diet_plans
+      SET is_active = FALSE,
+          updated_at = ${plan.updated_at},
+          data = jsonb_set(data, '{isActive}', 'false'::jsonb, true)
+      WHERE id <> ${plan.id} AND is_active = TRUE
+    `;
+  }
+}
+
 function jsonResponse(statusCode, body) {
   return {
     statusCode,
@@ -1107,6 +1432,278 @@ function resolveSubPath(event) {
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
 }
 
+async function handleMeals(event, subPath) {
+  if (!subPath.startsWith('/meals')) {
+    return null;
+  }
+
+  const sql = getSqlClient();
+  await ensureDatabase();
+
+  if (event.httpMethod === 'GET' && (subPath === '/meals' || subPath === '/meals/')) {
+    const order = typeof event.queryStringParameters?.order === 'string'
+      ? event.queryStringParameters.order
+      : '-created_date';
+    const direction = order.startsWith('-') ? 'DESC' : 'ASC';
+    const limitValue = Number(event.queryStringParameters?.limit);
+    const limitClause = Number.isFinite(limitValue) && limitValue > 0 ? sql`LIMIT ${limitValue}` : sql``;
+
+    const rows = await sql`
+      SELECT id, created_date, data
+      FROM meals
+      ORDER BY created_date ${direction === 'DESC' ? sql`DESC` : sql`ASC`}
+      ${limitClause}
+    `;
+
+    return jsonResponse(200, {
+      data: rows.map((row, index) => deserializeMealRow(row, index))
+    });
+  }
+
+  if (event.httpMethod === 'POST' && (subPath === '/meals' || subPath === '/meals/')) {
+    let payload;
+    try {
+      payload = JSON.parse(event.body || '{}');
+    } catch (error) {
+      return jsonResponse(400, { error: 'Invalid request payload.' });
+    }
+
+    const mealInput = payload?.meal;
+    if (!mealInput || typeof mealInput !== 'object') {
+      return jsonResponse(400, { error: 'meal payload is required.' });
+    }
+
+    const normalized = normalizeMealForStorage({ ...mealInput });
+    await upsertMeal(sql, normalized);
+
+    return jsonResponse(201, { data: normalized });
+  }
+
+  const mealMatch = subPath.match(/^\/meals\/([^/]+)$/);
+  if (mealMatch) {
+    const mealId = decodeURIComponent(mealMatch[1]);
+
+    if (event.httpMethod === 'GET') {
+      const rows = await sql`
+        SELECT id, created_date, data
+        FROM meals
+        WHERE id = ${mealId}
+        LIMIT 1
+      `;
+
+      if (!rows || rows.length === 0) {
+        return jsonResponse(404, { error: 'Meal not found.' });
+      }
+
+      return jsonResponse(200, { data: deserializeMealRow(rows[0]) });
+    }
+
+    if (event.httpMethod === 'PUT') {
+      let payload;
+      try {
+        payload = JSON.parse(event.body || '{}');
+      } catch (error) {
+        return jsonResponse(400, { error: 'Invalid request payload.' });
+      }
+
+      const mealUpdates = payload?.meal;
+      if (!mealUpdates || typeof mealUpdates !== 'object') {
+        return jsonResponse(400, { error: 'meal payload is required.' });
+      }
+
+      const existingRows = await sql`
+        SELECT id, created_date, data
+        FROM meals
+        WHERE id = ${mealId}
+        LIMIT 1
+      `;
+
+      if (!existingRows || existingRows.length === 0) {
+        return jsonResponse(404, { error: 'Meal not found.' });
+      }
+
+      const existing = deserializeMealRow(existingRows[0]);
+      const normalized = normalizeMealForStorage(
+        {
+          ...existing,
+          ...mealUpdates,
+          id: existing.id,
+          created_date: existing.created_date
+        }
+      );
+
+      await upsertMeal(sql, normalized);
+
+      return jsonResponse(200, { data: normalized });
+    }
+  }
+
+  return null;
+}
+
+async function handleDietPlans(event, subPath) {
+  if (!subPath.startsWith('/diet-plans')) {
+    return null;
+  }
+
+  const sql = getSqlClient();
+  await ensureDatabase();
+
+  if (event.httpMethod === 'GET' && (subPath === '/diet-plans' || subPath === '/diet-plans/')) {
+    const rows = await sql`
+      SELECT id, is_active, created_at, updated_at, data
+      FROM diet_plans
+      ORDER BY is_active DESC, created_at DESC
+    `;
+
+    return jsonResponse(200, {
+      data: rows.map((row, index) => deserializeDietPlanRow(row, index))
+    });
+  }
+
+  if (event.httpMethod === 'POST' && (subPath === '/diet-plans' || subPath === '/diet-plans/')) {
+    let payload;
+    try {
+      payload = JSON.parse(event.body || '{}');
+    } catch (error) {
+      return jsonResponse(400, { error: 'Invalid request payload.' });
+    }
+
+    const planInput = payload?.plan;
+    if (!planInput || typeof planInput !== 'object') {
+      return jsonResponse(400, { error: 'plan payload is required.' });
+    }
+
+    const nowIso = new Date().toISOString();
+    const normalized = normalizeDietPlanForStorage({
+      ...planInput,
+      id: planInput.id || `diet_plan_${generateId()}`,
+      source: planInput.source || 'custom',
+      created_at: planInput.created_at || planInput.createdAt || nowIso,
+      updated_at: nowIso,
+    });
+
+    await upsertDietPlan(sql, normalized);
+
+    const rows = await sql`
+      SELECT id, is_active, created_at, updated_at, data
+      FROM diet_plans
+      WHERE id = ${normalized.id}
+      LIMIT 1
+    `;
+
+    const savedRow = rows && rows.length > 0 ? rows[0] : null;
+    return jsonResponse(201, { data: savedRow ? deserializeDietPlanRow(savedRow) : normalized });
+  }
+
+  const activateMatch = subPath.match(/^\/diet-plans\/([^/]+)\/activate$/);
+  if (activateMatch) {
+    const planId = decodeURIComponent(activateMatch[1]);
+
+    const rows = await sql`
+      SELECT id, is_active, created_at, updated_at, data
+      FROM diet_plans
+      WHERE id = ${planId}
+      LIMIT 1
+    `;
+
+    if (!rows || rows.length === 0) {
+      return jsonResponse(404, { error: 'Diet plan not found.' });
+    }
+
+    const existing = deserializeDietPlanRow(rows[0]);
+    const nowIso = new Date().toISOString();
+    const normalized = normalizeDietPlanForStorage({
+      ...existing,
+      isActive: true,
+      updated_at: nowIso,
+    });
+
+    await upsertDietPlan(sql, normalized);
+
+    const updatedRows = await sql`
+      SELECT id, is_active, created_at, updated_at, data
+      FROM diet_plans
+      WHERE id = ${planId}
+      LIMIT 1
+    `;
+
+    const savedRow = updatedRows && updatedRows.length > 0 ? updatedRows[0] : null;
+    return jsonResponse(200, { data: savedRow ? deserializeDietPlanRow(savedRow) : normalized });
+  }
+
+  const planMatch = subPath.match(/^\/diet-plans\/([^/]+)$/);
+  if (planMatch) {
+    const planId = decodeURIComponent(planMatch[1]);
+
+    if (event.httpMethod === 'GET') {
+      const rows = await sql`
+        SELECT id, is_active, created_at, updated_at, data
+        FROM diet_plans
+        WHERE id = ${planId}
+        LIMIT 1
+      `;
+
+      if (!rows || rows.length === 0) {
+        return jsonResponse(404, { error: 'Diet plan not found.' });
+      }
+
+      return jsonResponse(200, { data: deserializeDietPlanRow(rows[0]) });
+    }
+
+    if (event.httpMethod === 'PUT') {
+      let payload;
+      try {
+        payload = JSON.parse(event.body || '{}');
+      } catch (error) {
+        return jsonResponse(400, { error: 'Invalid request payload.' });
+      }
+
+      const planUpdates = payload?.plan;
+      if (!planUpdates || typeof planUpdates !== 'object') {
+        return jsonResponse(400, { error: 'plan payload is required.' });
+      }
+
+      const rows = await sql`
+        SELECT id, is_active, created_at, updated_at, data
+        FROM diet_plans
+        WHERE id = ${planId}
+        LIMIT 1
+      `;
+
+      if (!rows || rows.length === 0) {
+        return jsonResponse(404, { error: 'Diet plan not found.' });
+      }
+
+      const existing = deserializeDietPlanRow(rows[0]);
+      const nowIso = new Date().toISOString();
+      const normalized = normalizeDietPlanForStorage({
+        ...existing,
+        ...planUpdates,
+        id: existing.id,
+        created_at: existing.created_at,
+        updated_at: nowIso,
+        source: planUpdates.source || existing.source,
+        isActive: typeof planUpdates.isActive === 'boolean' ? planUpdates.isActive : existing.isActive,
+      });
+
+      await upsertDietPlan(sql, normalized);
+
+      const updatedRows = await sql`
+        SELECT id, is_active, created_at, updated_at, data
+        FROM diet_plans
+        WHERE id = ${planId}
+        LIMIT 1
+      `;
+
+      const savedRow = updatedRows && updatedRows.length > 0 ? updatedRows[0] : null;
+      return jsonResponse(200, { data: savedRow ? deserializeDietPlanRow(savedRow) : normalized });
+    }
+  }
+
+  return null;
+}
+
 exports.handler = async function handler(event) {
   const subPath = resolveSubPath(event);
 
@@ -1115,10 +1712,20 @@ exports.handler = async function handler(event) {
       statusCode: 204,
       headers: {
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type'
       }
     };
+  }
+
+  const mealResponse = await handleMeals(event, subPath);
+  if (mealResponse) {
+    return mealResponse;
+  }
+
+  const dietPlanResponse = await handleDietPlans(event, subPath);
+  if (dietPlanResponse) {
+    return dietPlanResponse;
   }
 
   if (subPath === '/analyze' && event.httpMethod === 'POST') {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@netlify/blobs": "^6.5.0",
+    "@netlify/neon": "^0.10.1",
     "@hookform/resolvers": "^4.1.2",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",


### PR DESCRIPTION
## Summary
- replace the browser local storage implementation with fetch helpers that talk to Netlify API endpoints for meals and diet plans
- extend the Netlify `api` function to expose CRUD handlers backed by the Netlify Database using `@netlify/neon`
- add the `@netlify/neon` dependency to the project to enable database access

## Testing
- npm run lint *(fails: existing lint configuration treats many project files as missing Node/React globals)*

------
https://chatgpt.com/codex/tasks/task_b_68e162aefbc48328928860487e1a5a68