### PR TITLE
Improve Neon JSONB serialization and API responses

### DIFF
--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -1,5 +1,8 @@
 const { getStore } = require('@netlify/blobs');
+const { neon } = require('@netlify/neon');
 const crypto = require('crypto');
+const mealsSeed = require('../../src/data/meals.json');
+const dietPlansSeed = require('../../src/data/dietPlans.json');
 
 const OPENAI_REQUEST_TIMEOUT_MS = Number(process.env.OPENAI_REQUEST_TIMEOUT_MS || 20000);
 const OPENAI_ANALYSIS_TIMEOUT_MS = Number(
@@ -119,6 +122,13 @@ const NUTRIENT_FIELDS = [
   'vitamin_c',
   'vitamin_a'
 ];
+
+function generateId() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
 
 const DEFAULT_SUGGESTION_LIMIT = 7;
 const OPENAI_SUGGESTION_MODEL = process.env.OPENAI_SUGGESTION_MODEL || 'gpt-4o-mini';
@@ -314,7 +324,7 @@ const MOCK_RESPONSE = {
 function normalizeIngredient(ingredient, index = 0) {
   const safe = typeof ingredient === 'object' && ingredient !== null ? { ...ingredient } : {};
   const normalized = {
-    id: typeof safe.id === 'string' && safe.id.length > 0 ? safe.id : `ingredient_${Date.now()}_${index}`,
+    id: typeof safe.id === 'string' && safe.id.length > 0 ? safe.id : `ingredient_${generateId()}`,
     name:
       typeof safe.name === 'string' && safe.name.length > 0
         ? safe.name
@@ -1081,6 +1091,372 @@ async function analyzeWithOpenAI({ imageDataUrl }) {
   return cacheAnalysis(cacheKey, ensureNumbers(parsed));
 }
 
+const getSqlClient = (() => {
+  let client;
+
+  return () => {
+    if (!client) {
+      const connectionString =
+        process.env.NETLIFY_DATABASE_URL ||
+        process.env.NETLIFY_DATABASE_URL_UNPOOLED ||
+        process.env.DATABASE_URL;
+
+      if (!connectionString) {
+        throw new Error('NETLIFY_DATABASE_URL is not configured.');
+      }
+
+      client = neon(connectionString);
+    }
+
+    return client;
+  };
+})();
+
+function serializeForJsonb(value) {
+  try {
+    return JSON.stringify(value ?? null);
+  } catch (error) {
+    console.error('Failed to serialize value for jsonb column.', error, value);
+    return JSON.stringify(null);
+  }
+}
+
+let schemaInitializationPromise = null;
+
+function normalizeIngredientsList(ingredients = []) {
+  if (!Array.isArray(ingredients) || ingredients.length === 0) {
+    return [];
+  }
+
+  return ingredients.map((ingredient, index) => normalizeIngredient(ingredient, index));
+}
+
+function normalizeMealForStorage(meal, index = 0) {
+  const safe = typeof meal === 'object' && meal !== null ? { ...meal } : {};
+  const createdSource = safe.created_date || safe.createdDate || safe.meal_date;
+  const createdDate = createdSource ? new Date(createdSource) : new Date();
+  const createdIso = Number.isNaN(createdDate.getTime()) ? new Date().toISOString() : createdDate.toISOString();
+
+  const normalizedIngredients = normalizeIngredientsList(safe.ingredients);
+  const totals = normalizedIngredients.length > 0 ? sumNutrients(normalizedIngredients) : null;
+
+  const normalized = {
+    id: typeof safe.id === 'string' && safe.id.length > 0 ? safe.id : `meal_${generateId()}`,
+    meal_name: typeof safe.meal_name === 'string' ? safe.meal_name : '',
+    meal_type: typeof safe.meal_type === 'string' ? safe.meal_type : 'lunch',
+    analysis_notes: typeof safe.analysis_notes === 'string' ? safe.analysis_notes : '',
+    notes: typeof safe.notes === 'string' ? safe.notes : '',
+    photo_url: typeof safe.photo_url === 'string' ? safe.photo_url : '',
+    created_date: createdIso,
+    ingredients: normalizedIngredients
+  };
+
+  NUTRIENT_FIELDS.forEach((field) => {
+    const provided = Number(safe[field]);
+    normalized[field] = Number.isFinite(provided)
+      ? provided
+      : totals
+        ? totals[field]
+        : 0;
+  });
+
+  if (totals) {
+    NUTRIENT_FIELDS.forEach((field) => {
+      normalized[field] = totals[field];
+    });
+  }
+
+  if (normalized.ingredients.length === 0) {
+    normalized.ingredients = [
+      normalizeIngredient(
+        {
+          name: normalized.meal_name || 'Meal serving',
+          unit: 'serving',
+          amount: 1,
+          ...NUTRIENT_FIELDS.reduce(
+            (acc, field) => ({
+              ...acc,
+              [field]: Number.isFinite(Number(normalized[field])) ? Number(normalized[field]) : 0
+            }),
+            {}
+          )
+        },
+        0
+      )
+    ];
+  }
+
+  return normalized;
+}
+
+function parseJsonColumn(value, fallback = {}) {
+  if (value && typeof value === 'object') {
+    return { ...value };
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object') {
+        return { ...parsed };
+      }
+    } catch (error) {
+      console.error('Failed to parse JSON column payload:', error, value);
+    }
+  }
+
+  return { ...fallback };
+}
+
+function deserializeMealRow(row, index = 0) {
+  if (!row) {
+    return null;
+  }
+
+  const payload = parseJsonColumn(row.data);
+  const createdValue = row.created_date instanceof Date
+    ? row.created_date.toISOString()
+    : row.created_date || payload.created_date;
+
+  return normalizeMealForStorage(
+    {
+      ...payload,
+      id: row.id,
+      created_date: createdValue
+    },
+    index
+  );
+}
+
+function normalizeMacroTargetsForStorage(targets = {}) {
+  if (!targets || typeof targets !== 'object') {
+    return {};
+  }
+
+  return Object.entries(targets).reduce((acc, [key, value]) => {
+    const normalizedKey = typeof key === 'string' && key.length > 0 ? key.toLowerCase() : key;
+    const numericValue = Number(value);
+    acc[normalizedKey] = Number.isFinite(numericValue) ? Math.round(numericValue) : 0;
+    return acc;
+  }, {});
+}
+
+function normalizeMealGuidanceForStorage(entries = []) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries
+    .map((entry, index) => {
+      const safe = typeof entry === 'object' && entry !== null ? entry : {};
+      const name = typeof safe.name === 'string' && safe.name.length > 0
+        ? safe.name
+        : `Meal ${index + 1}`;
+      const description = typeof safe.description === 'string' ? safe.description : '';
+
+      if (!name && !description) {
+        return null;
+      }
+
+      return { name, description };
+    })
+    .filter(Boolean);
+}
+
+function normalizeDietPlanForStorage(plan, index = 0) {
+  const safe = typeof plan === 'object' && plan !== null ? { ...plan } : {};
+  const createdSource = safe.created_at || safe.createdAt;
+  const updatedSource = safe.updated_at || safe.updatedAt;
+  const createdAt = createdSource ? new Date(createdSource) : new Date();
+  const updatedAt = updatedSource ? new Date(updatedSource) : new Date();
+
+  const normalizedTargets = normalizeMacroTargetsForStorage(safe.macroTargets || safe.targets);
+  const hasTargets = Object.keys(normalizedTargets).length > 0;
+
+  const normalized = {
+    id:
+      typeof safe.id === 'string' && safe.id.length > 0
+        ? safe.id
+        : `diet_plan_${generateId()}`,
+    name:
+      typeof safe.name === 'string' && safe.name.length > 0
+        ? safe.name
+        : `Diet Plan ${index + 1}`,
+    goal: typeof safe.goal === 'string' ? safe.goal : '',
+    description: typeof safe.description === 'string' ? safe.description : '',
+    macroTargets: hasTargets
+      ? normalizedTargets
+      : {
+          calories: 2000,
+          protein: 100,
+          carbs: 220,
+          fat: 70,
+        },
+    hydrationTarget: Number.isFinite(Number(safe.hydrationTarget))
+      ? Number(safe.hydrationTarget)
+      : 8,
+    focus: Array.isArray(safe.focus) ? safe.focus.map((item) => String(item)) : [],
+    mealGuidance: normalizeMealGuidanceForStorage(safe.mealGuidance),
+    tips: Array.isArray(safe.tips) ? safe.tips.map((item) => String(item)) : [],
+    created_at: Number.isNaN(createdAt.getTime()) ? new Date().toISOString() : createdAt.toISOString(),
+    updated_at: Number.isNaN(updatedAt.getTime()) ? new Date().toISOString() : updatedAt.toISOString(),
+    isActive: Boolean(safe.isActive),
+    source:
+      typeof safe.source === 'string' && safe.source.length > 0
+        ? safe.source
+        : 'template',
+  };
+
+  return normalized;
+}
+
+function deserializeDietPlanRow(row, index = 0) {
+  if (!row) {
+    return null;
+  }
+
+  const payload = parseJsonColumn(row.data);
+  const createdAtValue = row.created_at instanceof Date
+    ? row.created_at.toISOString()
+    : row.created_at || payload.created_at;
+  const updatedAtValue = row.updated_at instanceof Date
+    ? row.updated_at.toISOString()
+    : row.updated_at || payload.updated_at;
+  const isActive = typeof row.is_active === 'boolean' ? row.is_active : Boolean(payload.isActive);
+
+  return normalizeDietPlanForStorage(
+    {
+      ...payload,
+      id: row.id,
+      created_at: createdAtValue,
+      updated_at: updatedAtValue,
+      isActive
+    },
+    index
+  );
+}
+
+async function initializeDatabase() {
+  const sql = getSqlClient();
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meals (
+      id TEXT PRIMARY KEY,
+      created_date TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      data JSONB NOT NULL
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS diet_plans (
+      id TEXT PRIMARY KEY,
+      is_active BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      data JSONB NOT NULL
+    )
+  `;
+
+  const mealCountResult = await sql`SELECT COUNT(*)::int AS count FROM meals`;
+  const mealCount = Number(mealCountResult?.[0]?.count || 0);
+
+  if (mealCount === 0 && Array.isArray(mealsSeed)) {
+    for (let index = 0; index < mealsSeed.length; index += 1) {
+      const normalized = normalizeMealForStorage(mealsSeed[index], index);
+      await sql`
+        INSERT INTO meals (id, created_date, data)
+        VALUES (${normalized.id}, ${normalized.created_date}, ${serializeForJsonb(normalized)}::jsonb)
+        ON CONFLICT (id) DO NOTHING
+      `;
+    }
+  }
+
+  const planCountResult = await sql`SELECT COUNT(*)::int AS count FROM diet_plans`;
+  const planCount = Number(planCountResult?.[0]?.count || 0);
+
+  if (planCount === 0 && Array.isArray(dietPlansSeed)) {
+    const seededPlans = dietPlansSeed.map((plan, index) =>
+      normalizeDietPlanForStorage(
+        {
+          ...plan,
+          isActive: index === 0,
+          created_at: plan?.created_at || plan?.createdAt || new Date().toISOString(),
+          updated_at: plan?.updated_at || plan?.updatedAt || new Date().toISOString(),
+        },
+        index
+      )
+    );
+
+    if (!seededPlans.some((plan) => plan.isActive) && seededPlans.length > 0) {
+      seededPlans[0].isActive = true;
+    }
+
+    for (const plan of seededPlans) {
+      await sql`
+        INSERT INTO diet_plans (id, is_active, created_at, updated_at, data)
+        VALUES (${plan.id}, ${plan.isActive}, ${plan.created_at}, ${plan.updated_at}, ${serializeForJsonb(plan)}::jsonb)
+        ON CONFLICT (id) DO NOTHING
+      `;
+    }
+  }
+}
+
+async function ensureDatabase() {
+  if (!schemaInitializationPromise) {
+    schemaInitializationPromise = initializeDatabase().catch((error) => {
+      schemaInitializationPromise = null;
+      throw error;
+    });
+  }
+
+  return schemaInitializationPromise;
+}
+
+async function upsertMeal(sql, meal) {
+  const rows = await sql`
+    INSERT INTO meals (id, created_date, data)
+    VALUES (${meal.id}, ${meal.created_date}, ${serializeForJsonb(meal)}::jsonb)
+    ON CONFLICT (id) DO UPDATE
+      SET created_date = EXCLUDED.created_date,
+          data = EXCLUDED.data
+    RETURNING id, created_date, data
+  `;
+
+  if (rows && rows.length > 0) {
+    return deserializeMealRow(rows[0]);
+  }
+
+  return normalizeMealForStorage(meal);
+}
+
+async function upsertDietPlan(sql, plan) {
+  const rows = await sql`
+    INSERT INTO diet_plans (id, is_active, created_at, updated_at, data)
+    VALUES (${plan.id}, ${plan.isActive}, ${plan.created_at}, ${plan.updated_at}, ${serializeForJsonb(plan)}::jsonb)
+    ON CONFLICT (id) DO UPDATE
+      SET is_active = EXCLUDED.is_active,
+          updated_at = EXCLUDED.updated_at,
+          data = EXCLUDED.data
+    RETURNING id, is_active, created_at, updated_at, data
+  `;
+
+  if (plan.isActive) {
+    await sql`
+      UPDATE diet_plans
+      SET is_active = FALSE,
+          updated_at = ${plan.updated_at},
+          data = jsonb_set(data, '{isActive}', 'false'::jsonb, true)
+      WHERE id <> ${plan.id} AND is_active = TRUE
+    `;
+  }
+
+  if (rows && rows.length > 0) {
+    return deserializeDietPlanRow(rows[0]);
+  }
+
+  return normalizeDietPlanForStorage(plan);
+}
+
 function jsonResponse(statusCode, body) {
   return {
     statusCode,
@@ -1091,6 +1467,59 @@ function jsonResponse(statusCode, body) {
     },
     body: JSON.stringify(body)
   };
+}
+
+function formatErrorForResponse(error, seen = new WeakSet()) {
+  if (!error || typeof error !== 'object') {
+    return { message: typeof error === 'string' ? error : 'Unknown error' };
+  }
+
+  if (seen.has(error)) {
+    return { message: 'Circular error reference detected.' };
+  }
+  seen.add(error);
+
+  const formatted = {
+    message:
+      typeof error.message === 'string' && error.message.length > 0
+        ? error.message
+        : 'Unknown error',
+  };
+
+  if (typeof error.name === 'string' && error.name.length > 0) {
+    formatted.name = error.name;
+  }
+
+  if (typeof error.code !== 'undefined' && error.code !== null) {
+    formatted.code = String(error.code);
+  }
+
+  if (typeof error.status === 'number' && Number.isFinite(error.status)) {
+    formatted.status = error.status;
+  }
+
+  if (
+    typeof error.statusCode === 'number' &&
+    Number.isFinite(error.statusCode) &&
+    error.statusCode !== error.status
+  ) {
+    formatted.statusCode = error.statusCode;
+  }
+
+  if (typeof error.stack === 'string' && error.stack.length > 0) {
+    formatted.stack = error.stack
+      .split('\n')
+      .slice(0, 5)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  if (typeof error.cause === 'object' && error.cause) {
+    formatted.cause = formatErrorForResponse(error.cause, seen);
+  }
+
+  return formatted;
 }
 
 function resolveSubPath(event) {
@@ -1107,6 +1536,354 @@ function resolveSubPath(event) {
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
 }
 
+async function handleMeals(event, subPath) {
+  if (!subPath.startsWith('/meals')) {
+    return null;
+  }
+
+  let sql;
+
+  try {
+    sql = getSqlClient();
+    await ensureDatabase();
+  } catch (error) {
+    console.error('Failed to initialize the Netlify database client for meal operations:', error);
+    return jsonResponse(500, {
+      error:
+        'Unable to connect to the Netlify Database. Please verify that NETLIFY_DATABASE_URL is configured correctly.',
+      details: formatErrorForResponse(error),
+    });
+  }
+
+  try {
+    if (event.httpMethod === 'GET' && (subPath === '/meals' || subPath === '/meals/')) {
+      const order = typeof event.queryStringParameters?.order === 'string'
+        ? event.queryStringParameters.order
+        : '-created_date';
+      const direction = order.startsWith('-') ? 'DESC' : 'ASC';
+      const limitValue = Number(event.queryStringParameters?.limit);
+      const limitClause = Number.isFinite(limitValue) && limitValue > 0 ? sql`LIMIT ${limitValue}` : sql``;
+
+      const rows = await sql`
+        SELECT id, created_date, data
+        FROM meals
+        ORDER BY created_date ${direction === 'DESC' ? sql`DESC` : sql`ASC`}
+        ${limitClause}
+      `;
+
+      return jsonResponse(200, {
+        data: rows.map((row, index) => deserializeMealRow(row, index))
+      });
+    }
+
+    if (event.httpMethod === 'POST' && (subPath === '/meals' || subPath === '/meals/')) {
+      let payload;
+      try {
+        payload = JSON.parse(event.body || '{}');
+      } catch (error) {
+        return jsonResponse(400, { error: 'Invalid request payload.' });
+      }
+
+      const mealInput = payload?.meal;
+      if (!mealInput || typeof mealInput !== 'object') {
+        return jsonResponse(400, { error: 'meal payload is required.' });
+      }
+
+      const normalized = normalizeMealForStorage({ ...mealInput });
+      const savedMeal = await upsertMeal(sql, normalized);
+
+      return jsonResponse(201, { data: savedMeal });
+    }
+
+    const mealMatch = subPath.match(/^\/meals\/([^/]+)$/);
+    if (mealMatch) {
+      const mealId = decodeURIComponent(mealMatch[1]);
+
+      if (event.httpMethod === 'GET') {
+        const rows = await sql`
+          SELECT id, created_date, data
+          FROM meals
+          WHERE id = ${mealId}
+          LIMIT 1
+        `;
+
+        if (!rows || rows.length === 0) {
+          return jsonResponse(404, { error: 'Meal not found.' });
+        }
+
+        return jsonResponse(200, { data: deserializeMealRow(rows[0]) });
+      }
+
+      if (event.httpMethod === 'PUT') {
+        let payload;
+        try {
+          payload = JSON.parse(event.body || '{}');
+        } catch (error) {
+          return jsonResponse(400, { error: 'Invalid request payload.' });
+        }
+
+        const mealUpdates = payload?.meal;
+        if (!mealUpdates || typeof mealUpdates !== 'object') {
+          return jsonResponse(400, { error: 'meal payload is required.' });
+        }
+
+        const existingRows = await sql`
+          SELECT id, created_date, data
+          FROM meals
+          WHERE id = ${mealId}
+          LIMIT 1
+        `;
+
+        if (!existingRows || existingRows.length === 0) {
+          return jsonResponse(404, { error: 'Meal not found.' });
+        }
+
+        const existing = deserializeMealRow(existingRows[0]);
+        const normalized = normalizeMealForStorage(
+          {
+            ...existing,
+            ...mealUpdates,
+            id: existing.id,
+            created_date: existing.created_date
+          }
+        );
+
+        const savedMeal = await upsertMeal(sql, normalized);
+
+        return jsonResponse(200, { data: savedMeal });
+      }
+
+      if (event.httpMethod === 'DELETE') {
+        const deleteResult = await sql`
+          DELETE FROM meals
+          WHERE id = ${mealId}
+          RETURNING id
+        `;
+
+        if (!deleteResult || deleteResult.length === 0) {
+          return jsonResponse(404, { error: 'Meal not found.' });
+        }
+
+        return jsonResponse(200, { data: { id: mealId }, success: true });
+      }
+    }
+  } catch (error) {
+    console.error('Failed to process meal request via Netlify function:', error);
+    return jsonResponse(500, {
+      error: 'Failed to process the meal request. Please try again or check the Netlify Database configuration.',
+      details: formatErrorForResponse(error),
+      request: {
+        method: event.httpMethod,
+        path: subPath,
+      },
+    });
+  }
+
+  return null;
+}
+
+async function handleDietPlans(event, subPath) {
+  if (!subPath.startsWith('/diet-plans')) {
+    return null;
+  }
+
+  let sql;
+
+  try {
+    sql = getSqlClient();
+    await ensureDatabase();
+  } catch (error) {
+    console.error('Failed to initialize the Netlify database client for diet plan operations:', error);
+    return jsonResponse(500, {
+      error:
+        'Unable to connect to the Netlify Database. Please verify that NETLIFY_DATABASE_URL is configured correctly.',
+      details: formatErrorForResponse(error),
+    });
+  }
+
+  try {
+    if (event.httpMethod === 'GET' && (subPath === '/diet-plans' || subPath === '/diet-plans/')) {
+      const rows = await sql`
+        SELECT id, is_active, created_at, updated_at, data
+        FROM diet_plans
+        ORDER BY is_active DESC, created_at DESC
+      `;
+
+      const rawPlans = rows.map((row, index) => deserializeDietPlanRow(row, index));
+      const queryParams = event.queryStringParameters || {};
+      const sourceFilter =
+        typeof queryParams.source === 'string' && queryParams.source.trim().length > 0
+          ? queryParams.source.trim()
+          : '';
+      const excludeSource =
+        typeof queryParams.exclude_source === 'string' && queryParams.exclude_source.trim().length > 0
+          ? queryParams.exclude_source.trim()
+          : '';
+
+      const filteredPlans = rawPlans.filter((plan) => {
+        if (!plan) {
+          return false;
+        }
+
+        if (sourceFilter && plan.source !== sourceFilter) {
+          return false;
+        }
+
+        if (excludeSource && plan.source === excludeSource) {
+          return false;
+        }
+
+        return true;
+      });
+
+      return jsonResponse(200, {
+        data: filteredPlans
+      });
+    }
+
+    if (event.httpMethod === 'POST' && (subPath === '/diet-plans' || subPath === '/diet-plans/')) {
+      let payload;
+      try {
+        payload = JSON.parse(event.body || '{}');
+      } catch (error) {
+        return jsonResponse(400, { error: 'Invalid request payload.' });
+      }
+
+      const planInput = payload?.plan;
+      if (!planInput || typeof planInput !== 'object') {
+        return jsonResponse(400, { error: 'plan payload is required.' });
+      }
+
+      const nowIso = new Date().toISOString();
+      const normalized = normalizeDietPlanForStorage({
+        ...planInput,
+        id: planInput.id || `diet_plan_${generateId()}`,
+        source: planInput.source || 'custom',
+        created_at: planInput.created_at || planInput.createdAt || nowIso,
+        updated_at: nowIso,
+      });
+
+      const savedPlan = await upsertDietPlan(sql, normalized);
+
+      return jsonResponse(201, { data: savedPlan });
+    }
+
+    const activateMatch = subPath.match(/^\/diet-plans\/([^/]+)\/activate$/);
+    if (activateMatch) {
+      const planId = decodeURIComponent(activateMatch[1]);
+
+      const rows = await sql`
+        SELECT id, is_active, created_at, updated_at, data
+        FROM diet_plans
+        WHERE id = ${planId}
+        LIMIT 1
+      `;
+
+      if (!rows || rows.length === 0) {
+        return jsonResponse(404, { error: 'Diet plan not found.' });
+      }
+
+      const existing = deserializeDietPlanRow(rows[0]);
+      const normalized = normalizeDietPlanForStorage({
+        ...existing,
+        isActive: true,
+        updated_at: new Date().toISOString(),
+      });
+
+      const savedPlan = await upsertDietPlan(sql, normalized);
+
+      return jsonResponse(200, { data: savedPlan });
+    }
+
+    const planMatch = subPath.match(/^\/diet-plans\/([^/]+)$/);
+    if (planMatch) {
+      const planId = decodeURIComponent(planMatch[1]);
+
+      if (event.httpMethod === 'GET') {
+        const rows = await sql`
+          SELECT id, is_active, created_at, updated_at, data
+          FROM diet_plans
+          WHERE id = ${planId}
+          LIMIT 1
+        `;
+
+        if (!rows || rows.length === 0) {
+          return jsonResponse(404, { error: 'Diet plan not found.' });
+        }
+
+        return jsonResponse(200, { data: deserializeDietPlanRow(rows[0]) });
+      }
+
+      if (event.httpMethod === 'PUT') {
+        let payload;
+        try {
+          payload = JSON.parse(event.body || '{}');
+        } catch (error) {
+          return jsonResponse(400, { error: 'Invalid request payload.' });
+        }
+
+        const planUpdates = payload?.plan;
+        if (!planUpdates || typeof planUpdates !== 'object') {
+          return jsonResponse(400, { error: 'plan payload is required.' });
+        }
+
+        const rows = await sql`
+          SELECT id, is_active, created_at, updated_at, data
+          FROM diet_plans
+          WHERE id = ${planId}
+          LIMIT 1
+        `;
+
+        if (!rows || rows.length === 0) {
+          return jsonResponse(404, { error: 'Diet plan not found.' });
+        }
+
+        const existing = deserializeDietPlanRow(rows[0]);
+        const nowIso = new Date().toISOString();
+        const normalized = normalizeDietPlanForStorage({
+          ...existing,
+          ...planUpdates,
+          id: existing.id,
+          created_at: existing.created_at,
+          updated_at: nowIso,
+          source: planUpdates.source || existing.source,
+          isActive: typeof planUpdates.isActive === 'boolean' ? planUpdates.isActive : existing.isActive,
+        });
+
+        const savedPlan = await upsertDietPlan(sql, normalized);
+
+        return jsonResponse(200, { data: savedPlan });
+      }
+
+      if (event.httpMethod === 'DELETE') {
+        const deleteResult = await sql`
+          DELETE FROM diet_plans
+          WHERE id = ${planId}
+          RETURNING id
+        `;
+
+        if (!deleteResult || deleteResult.length === 0) {
+          return jsonResponse(404, { error: 'Diet plan not found.' });
+        }
+
+        return jsonResponse(200, { data: { id: planId }, success: true });
+      }
+    }
+  } catch (error) {
+    console.error('Failed to process diet plan request via Netlify function:', error);
+    return jsonResponse(500, {
+      error: 'Failed to process the diet plan request. Please try again or check the Netlify Database configuration.',
+      details: formatErrorForResponse(error),
+      request: {
+        method: event.httpMethod,
+        path: subPath,
+      },
+    });
+  }
+
+  return null;
+}
+
 exports.handler = async function handler(event) {
   const subPath = resolveSubPath(event);
 
@@ -1115,10 +1892,20 @@ exports.handler = async function handler(event) {
       statusCode: 204,
       headers: {
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type'
       }
     };
+  }
+
+  const mealResponse = await handleMeals(event, subPath);
+  if (mealResponse) {
+    return mealResponse;
+  }
+
+  const dietPlanResponse = await handleDietPlans(event, subPath);
+  if (dietPlanResponse) {
+    return dietPlanResponse;
   }
 
   if (subPath === '/analyze' && event.httpMethod === 'POST') {
@@ -1134,7 +1921,10 @@ exports.handler = async function handler(event) {
       return jsonResponse(200, { data: analysis });
     } catch (error) {
       console.error('Failed to analyze meal image via Netlify function:', error);
-      return jsonResponse(500, { error: error.message || 'Failed to analyze the meal image.' });
+      return jsonResponse(500, {
+        error: error.message || 'Failed to analyze the meal image.',
+        details: formatErrorForResponse(error),
+      });
     }
   }
 
@@ -1174,7 +1964,10 @@ exports.handler = async function handler(event) {
       return jsonResponse(200, { data: suggestions });
     } catch (error) {
       console.error('Failed to provide ingredient suggestions via Netlify function:', error);
-      return jsonResponse(500, { error: error.message || 'Failed to fetch ingredient suggestions.' });
+      return jsonResponse(500, {
+        error: error.message || 'Failed to fetch ingredient suggestions.',
+        details: formatErrorForResponse(error),
+      });
     }
   }
 
@@ -1194,6 +1987,7 @@ exports.handler = async function handler(event) {
         console.error('Failed to store meal photo in Netlify Blobs:', error);
         return jsonResponse(502, {
           error: error.message || 'Unable to store the meal photo at this time.',
+          details: formatErrorForResponse(error),
         });
       }
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@netlify/blobs": "^6.5.0",
+    "@netlify/neon": "latest",
     "@hookform/resolvers": "^4.1.2",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -3,13 +3,16 @@ import {
   createMeal,
   getMealById,
   updateMeal,
+  deleteMeal,
   subscribeToMealChanges,
   listDietPlans,
+  listDietPlanTemplates,
   createDietPlan,
   updateDietPlan,
   setActiveDietPlan,
   getActiveDietPlan,
   getDietPlanById,
+  deleteDietPlan,
 } from './storage';
 
 export const Meal = {
@@ -17,6 +20,7 @@ export const Meal = {
   create: (meal) => createMeal(meal),
   get: (id) => getMealById(id),
   update: (id, updates) => updateMeal(id, updates),
+  delete: (id) => deleteMeal(id),
   subscribe: (listener, options) => subscribeToMealChanges(listener, options)
 };
 
@@ -27,10 +31,12 @@ export const User = {
 };
 
 export const DietPlan = {
-  list: () => listDietPlans(),
+  list: (options) => listDietPlans(options),
+  listTemplates: () => listDietPlanTemplates(),
   get: (id) => getDietPlanById(id),
   create: (plan) => createDietPlan(plan),
   update: (id, updates) => updateDietPlan(id, updates),
   setActive: (id) => setActiveDietPlan(id),
   getActive: () => getActiveDietPlan(),
+  delete: (id) => deleteDietPlan(id),
 };

--- a/src/api/storage.js
+++ b/src/api/storage.js
@@ -1,10 +1,5 @@
-import mealsSeed from '@/data/meals.json';
-import dietPlansSeed from '@/data/dietPlans.json';
-
 const NETLIFY_UPLOAD_ENDPOINT = '/api/upload-photo';
-
-const STORAGE_KEY = 'nutri-scan:meals';
-const DIET_PLAN_STORAGE_KEY = 'nutri-scan:diet-plans';
+const API_BASE_PATH = '/api';
 
 let cachedMeals = null;
 let cachedDietPlans = null;
@@ -43,24 +38,6 @@ const UNIT_ALIASES = {
   portions: 'serving'
 };
 
-function canonicalizeUnit(unit) {
-  if (typeof unit !== 'string') {
-    return 'g';
-  }
-
-  const normalized = unit.trim().toLowerCase();
-  if (normalized.length === 0) {
-    return 'g';
-  }
-
-  const mapped = UNIT_ALIASES[normalized];
-  if (mapped) {
-    return mapped;
-  }
-
-  return CANONICAL_UNITS.includes(normalized) ? normalized : 'g';
-}
-
 const NUTRIENT_FIELDS = [
   'calories',
   'protein',
@@ -82,6 +59,24 @@ function generateId() {
     return globalCrypto.randomUUID();
   }
   return `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+function canonicalizeUnit(unit) {
+  if (typeof unit !== 'string') {
+    return 'g';
+  }
+
+  const normalized = unit.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return 'g';
+  }
+
+  const mapped = UNIT_ALIASES[normalized];
+  if (mapped) {
+    return mapped;
+  }
+
+  return CANONICAL_UNITS.includes(normalized) ? normalized : 'g';
 }
 
 function normalizeIngredient(ingredient, index = 0) {
@@ -125,6 +120,10 @@ function sumNutrients(ingredients) {
 }
 
 function withDefaults(meal) {
+  if (!meal || typeof meal !== 'object') {
+    return withDefaults({});
+  }
+
   const ingredients = normalizeIngredients(meal.ingredients);
   const totals = ingredients.length > 0 ? sumNutrients(ingredients) : null;
 
@@ -183,7 +182,6 @@ async function uploadPhotoIfNeeded(photoUrl) {
     return '';
   }
 
-  // Skip uploads for already hosted images.
   if (!photoUrl.startsWith('data:')) {
     return photoUrl;
   }
@@ -211,19 +209,6 @@ async function uploadPhotoIfNeeded(photoUrl) {
   }
 
   return photoUrl;
-}
-
-function readFromLocalStorage() {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-  try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    return stored ? JSON.parse(stored) : null;
-  } catch (error) {
-    console.warn('Unable to read meals from localStorage:', error);
-    return null;
-  }
 }
 
 function cloneIngredients(ingredients) {
@@ -286,122 +271,253 @@ function notifyMealListeners() {
   });
 }
 
-function prepareMealsForStorage(meals, { stripInlinePhotos = false } = {}) {
-  if (!Array.isArray(meals)) {
-    return [];
+class ApiError extends Error {
+  constructor(message, status, payload) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.payload = payload;
   }
-
-  return meals.map((meal) => {
-    const safeMeal = { ...(typeof meal === 'object' && meal !== null ? meal : {}) };
-
-    if (stripInlinePhotos && typeof safeMeal.photo_url === 'string' && safeMeal.photo_url.startsWith('data:')) {
-      safeMeal.photo_url = '';
-    }
-
-    safeMeal.ingredients = cloneIngredients(safeMeal.ingredients);
-    return safeMeal;
-  });
 }
 
-function isQuotaExceededError(error) {
-  if (!error) {
+async function fetchJson(path, options = {}) {
+  const { method = 'GET', body, headers = {} } = options;
+  let requestBody = body;
+  const requestHeaders = { ...headers };
+
+  if (body && typeof body === 'object' && !(body instanceof FormData)) {
+    requestBody = JSON.stringify(body);
+    if (!requestHeaders['Content-Type']) {
+      requestHeaders['Content-Type'] = 'application/json';
+    }
+  }
+
+  let response;
+  try {
+    response = await fetch(`${API_BASE_PATH}${path}`, {
+      method,
+      headers: requestHeaders,
+      body: requestBody
+    });
+  } catch (networkError) {
+    console.error(`Network error while calling ${path}:`, networkError);
+    const error = new ApiError(
+      `Unable to reach the server for ${path}: ${networkError.message}`,
+      0,
+      null
+    );
+    error.cause = networkError;
+    throw error;
+  }
+
+  const text = await response.text();
+
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch (parseError) {
+      console.error(`Failed to parse JSON response from ${path}:`, parseError, text);
+      const error = new ApiError(
+        `Received invalid JSON from ${path}: ${parseError.message}`,
+        response.status,
+        { raw: text }
+      );
+      error.cause = parseError;
+      throw error;
+    }
+  }
+
+  if (!response.ok) {
+    const messageParts = [];
+    if (payload?.error && typeof payload.error === 'string') {
+      messageParts.push(payload.error);
+    }
+
+    const detailMessage = payload?.details?.message;
+    if (detailMessage && typeof detailMessage === 'string') {
+      messageParts.push(detailMessage);
+    }
+
+    if (messageParts.length === 0) {
+      messageParts.push(`Request to ${path} failed with status ${response.status}.`);
+    }
+
+    throw new ApiError(messageParts.join(' — '), response.status, payload ?? { raw: text });
+  }
+
+  return payload;
+}
+
+function sortMeals(meals, order = '-created_date') {
+  const sortValue = typeof order === 'string' && order.length > 0 ? order : '-created_date';
+  const direction = sortValue.startsWith('-') ? -1 : 1;
+  const key = sortValue.replace('-', '') || 'created_date';
+
+  const safeMeals = Array.isArray(meals) ? [...meals] : [];
+  safeMeals.sort((a, b) => {
+    const aValue = new Date(a[key] || a.created_date || 0).getTime();
+    const bValue = new Date(b[key] || b.created_date || 0).getTime();
+    return (aValue - bValue) * direction;
+  });
+
+  return safeMeals;
+}
+
+async function loadMeals({ force = false } = {}) {
+  if (!cachedMeals || force) {
+    const payload = await fetchJson('/meals');
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    cachedMeals = rows.map((meal) => withDefaults(meal));
+  }
+
+  return cachedMeals || [];
+}
+
+function insertMealIntoCache(meal) {
+  const normalized = withDefaults(meal);
+  const existing = Array.isArray(cachedMeals) ? [...cachedMeals] : [];
+  const filtered = existing.filter((item) => item?.id !== normalized.id);
+  filtered.push(normalized);
+  cachedMeals = sortMeals(filtered, '-created_date');
+  notifyMealListeners();
+  return normalized;
+}
+
+function removeMealFromCache(id) {
+  if (!id || !Array.isArray(cachedMeals)) {
     return false;
   }
 
-  if (error?.name === 'QuotaExceededError') {
-    return true;
+  const nextMeals = cachedMeals.filter((meal) => meal?.id !== id);
+
+  if (nextMeals.length === cachedMeals.length) {
+    return false;
   }
 
-  const message = String(error?.message || '');
-  return message.toLowerCase().includes('quota');
+  cachedMeals = nextMeals;
+  notifyMealListeners();
+  return true;
 }
 
-function writeToLocalStorage(meals) {
-  if (typeof window === 'undefined') {
-    return;
+export function subscribeToMealChanges(listener, { immediate = false } = {}) {
+  if (typeof listener !== 'function') {
+    return () => {};
   }
 
-  const attempts = [
-    { stripInlinePhotos: false, logFallback: false },
-    { stripInlinePhotos: true, logFallback: true }
-  ];
+  mealListeners.add(listener);
 
-  for (const attempt of attempts) {
-    try {
-      const payload = JSON.stringify(prepareMealsForStorage(meals, attempt));
-      window.localStorage.setItem(STORAGE_KEY, payload);
-
-      if (attempt.logFallback) {
-        console.warn(
-          'Inline meal photos were removed before saving to keep storage usage within browser limits.'
-        );
+  if (immediate) {
+    (async () => {
+      try {
+        await loadMeals();
+        listener(createMealsSnapshot());
+      } catch (error) {
+        console.error('Unable to deliver the initial meals snapshot to a listener:', error);
       }
+    })();
+  }
 
-      return;
-    } catch (error) {
-      if (!isQuotaExceededError(error) || attempt.stripInlinePhotos) {
-        console.warn('Unable to persist meals to localStorage:', error);
-        return;
+  return () => {
+    mealListeners.delete(listener);
+  };
+}
+
+export async function listMeals(order = '-created_date', limit) {
+  const meals = await loadMeals();
+  const sorted = sortMeals(meals, order);
+  return typeof limit === 'number' ? sorted.slice(0, limit) : sorted;
+}
+
+export async function createMeal(meal) {
+  const storedPhotoUrl = await uploadPhotoIfNeeded(meal.photo_url);
+  const payload = await fetchJson('/meals', {
+    method: 'POST',
+    body: {
+      meal: {
+        ...meal,
+        photo_url: storedPhotoUrl
       }
-    }
-  }
-}
-
-function syncCachedMealsFromStorage(rawValue) {
-  if (rawValue === null) {
-    cachedMeals = [];
-    notifyMealListeners();
-    return;
-  }
-
-  if (typeof rawValue !== 'string') {
-    return;
-  }
-
-  try {
-    const parsed = JSON.parse(rawValue);
-    if (Array.isArray(parsed)) {
-      cachedMeals = parsed.map(withDefaults);
-      notifyMealListeners();
-    }
-  } catch (error) {
-    console.warn('Unable to synchronize meals from storage event:', error);
-  }
-}
-
-if (typeof window !== 'undefined' && !window.__nutriScanMealsStorageListener) {
-  window.__nutriScanMealsStorageListener = true;
-  window.addEventListener('storage', (event) => {
-    if (event.key === STORAGE_KEY) {
-      syncCachedMealsFromStorage(event.newValue);
     }
   });
+
+  const saved = payload?.data ? payload.data : null;
+  if (!saved) {
+    throw new Error('The server did not return the saved meal.');
+  }
+
+  return insertMealIntoCache(saved);
 }
 
-function readPlansFromLocalStorage() {
-  if (typeof window === 'undefined') {
+export async function getMealById(id) {
+  if (!id) {
     return null;
   }
 
+  if (Array.isArray(cachedMeals)) {
+    const cached = cachedMeals.find((meal) => meal.id === id);
+    if (cached) {
+      return withDefaults(cached);
+    }
+  }
+
   try {
-    const stored = window.localStorage.getItem(DIET_PLAN_STORAGE_KEY);
-    return stored ? JSON.parse(stored) : null;
+    const payload = await fetchJson(`/meals/${encodeURIComponent(id)}`);
+    if (!payload?.data) {
+      return null;
+    }
+    return insertMealIntoCache(payload.data);
   } catch (error) {
-    console.warn('Unable to read diet plans from localStorage:', error);
-    return null;
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
   }
 }
 
-function writePlansToLocalStorage(plans) {
-  if (typeof window === 'undefined') {
-    return;
+export async function updateMeal(id, updates = {}) {
+  if (!id) {
+    throw new Error('An id is required to update a meal.');
   }
 
-  try {
-    window.localStorage.setItem(DIET_PLAN_STORAGE_KEY, JSON.stringify(plans));
-  } catch (error) {
-    console.warn('Unable to persist diet plans to localStorage:', error);
+  const meals = Array.isArray(cachedMeals) ? cachedMeals : await loadMeals();
+  const existing = meals.find((meal) => meal.id === id);
+
+  if (!existing) {
+    throw new Error('Meal not found.');
   }
+
+  const nextPhotoSource =
+    typeof updates.photo_url === 'string' && updates.photo_url.length > 0
+      ? updates.photo_url
+      : existing.photo_url;
+  const storedPhotoUrl = await uploadPhotoIfNeeded(nextPhotoSource);
+
+  const payload = await fetchJson(`/meals/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body: {
+      meal: {
+        ...updates,
+        photo_url: storedPhotoUrl
+      }
+    }
+  });
+
+  const saved = payload?.data ? payload.data : null;
+  if (!saved) {
+    throw new Error('The server did not return the updated meal.');
+  }
+
+  return insertMealIntoCache(saved);
+}
+
+export async function deleteMeal(id) {
+  if (!id) {
+    throw new Error('An id is required to delete a meal.');
+  }
+
+  await fetchJson(`/meals/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  removeMealFromCache(id);
 }
 
 function normalizeMacroTargets(targets = {}) {
@@ -507,185 +623,19 @@ function clonePlan(plan) {
   };
 }
 
-function hydrateDietPlanSeed() {
-  const hydrated = dietPlansSeed.map((plan, index) =>
-    withPlanDefaults(
-      {
-        ...plan,
-        isActive: index === 0,
-        source: 'template',
-      },
-      index,
-    ),
-  );
-
-  if (!hydrated.some((plan) => plan.isActive) && hydrated.length > 0) {
-    hydrated[0] = { ...hydrated[0], isActive: true };
+async function loadDietPlans({ force = false } = {}) {
+  if (!cachedDietPlans || force) {
+    const payload = await fetchJson('/diet-plans');
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    cachedDietPlans = rows.map((plan, index) => withPlanDefaults(plan, index));
   }
 
-  return hydrated;
+  return cachedDietPlans || [];
 }
 
-async function getDietPlans() {
-  if (cachedDietPlans) {
-    return cachedDietPlans;
-  }
-
-  const stored = readPlansFromLocalStorage();
-  if (stored && Array.isArray(stored)) {
-    const normalized = stored.map((plan, index) => withPlanDefaults(plan, index));
-
-    if (!normalized.some((plan) => plan.isActive) && normalized.length > 0) {
-      normalized[0] = { ...normalized[0], isActive: true };
-    }
-
-    cachedDietPlans = normalized;
-    return cachedDietPlans;
-  }
-
-  cachedDietPlans = hydrateDietPlanSeed();
-  writePlansToLocalStorage(cachedDietPlans);
-  return cachedDietPlans;
-}
-
-function hydrateSeedData() {
-  return mealsSeed.map((meal) => {
-    const createdDate = meal.created_date
-      ?? (meal.meal_date ? new Date(meal.meal_date).toISOString() : new Date().toISOString());
-
-    return withDefaults({
-      ...meal,
-      created_date: createdDate
-    });
-  });
-}
-
-async function getMeals() {
-  if (cachedMeals) {
-    return cachedMeals;
-  }
-
-  const stored = readFromLocalStorage();
-  if (stored && Array.isArray(stored)) {
-    cachedMeals = stored.map(withDefaults);
-    return cachedMeals;
-  }
-
-  cachedMeals = hydrateSeedData();
-  writeToLocalStorage(cachedMeals);
-  return cachedMeals;
-}
-
-export function subscribeToMealChanges(listener, { immediate = false } = {}) {
-  if (typeof listener !== 'function') {
-    return () => {};
-  }
-
-  mealListeners.add(listener);
-
-  if (immediate) {
-    (async () => {
-      try {
-        await getMeals();
-        listener(createMealsSnapshot());
-      } catch (error) {
-        console.error('Unable to deliver the initial meals snapshot to a listener:', error);
-      }
-    })();
-  }
-
-  return () => {
-    mealListeners.delete(listener);
-  };
-}
-
-export async function listMeals(order = '-created_date', limit) {
-  const meals = await getMeals();
-  const sortValue = typeof order === 'string' && order.length > 0 ? order : '-created_date';
-  const direction = sortValue.startsWith('-') ? -1 : 1;
-  const key = sortValue.replace('-', '') || 'created_date';
-
-  const sorted = [...meals].sort((a, b) => {
-    const aValue = new Date(a[key] || a.created_date || 0).getTime();
-    const bValue = new Date(b[key] || b.created_date || 0).getTime();
-    return (aValue - bValue) * direction;
-  });
-
-  return typeof limit === 'number' ? sorted.slice(0, limit) : sorted;
-}
-
-export async function createMeal(meal) {
-  const meals = await getMeals();
-  const storedPhotoUrl = await uploadPhotoIfNeeded(meal.photo_url);
-  const newMeal = withDefaults({
-    ...meal,
-    id: `meal_${generateId()}`,
-    created_date: new Date().toISOString(),
-    photo_url: storedPhotoUrl
-  });
-
-  meals.unshift(newMeal);
-  cachedMeals = meals;
-  writeToLocalStorage(meals);
-  notifyMealListeners();
-  return newMeal;
-}
-
-export async function getMealById(id) {
-  if (!id) {
-    return null;
-  }
-
-  const meals = await getMeals();
-  const found = meals.find((meal) => meal.id === id);
-  return found ? withDefaults(found) : null;
-}
-
-export async function updateMeal(id, updates = {}) {
-  if (!id) {
-    throw new Error('An id is required to update a meal.');
-  }
-
-  const meals = await getMeals();
-  const index = meals.findIndex((meal) => meal.id === id);
-
-  if (index === -1) {
-    throw new Error('Meal not found.');
-  }
-
-  const existing = meals[index];
-  const nextPhotoSource =
-    typeof updates.photo_url === 'string' && updates.photo_url.length > 0
-      ? updates.photo_url
-      : existing.photo_url;
-  const storedPhotoUrl = await uploadPhotoIfNeeded(nextPhotoSource);
-
-  const updatedMeal = withDefaults({
-    ...existing,
-    ...updates,
-    id: existing.id,
-    created_date: existing.created_date,
-    photo_url: storedPhotoUrl
-  });
-
-  meals[index] = updatedMeal;
-  cachedMeals = meals;
-  writeToLocalStorage(meals);
-  notifyMealListeners();
-  return updatedMeal;
-}
-
-export async function clearMeals() {
-  cachedMeals = hydrateSeedData();
-  writeToLocalStorage(cachedMeals);
-  notifyMealListeners();
-  return cachedMeals;
-}
-
-export async function listDietPlans() {
-  const plans = await getDietPlans();
-
-  const sorted = [...plans].sort((a, b) => {
+function sortPlans(plans) {
+  const safePlans = Array.isArray(plans) ? [...plans] : [];
+  safePlans.sort((a, b) => {
     if (a.isActive && !b.isActive) return -1;
     if (!a.isActive && b.isActive) return 1;
 
@@ -693,8 +643,27 @@ export async function listDietPlans() {
     const bTime = new Date(b.created_at || b.createdAt || 0).getTime();
     return bTime - aTime;
   });
+  return safePlans;
+}
 
-  return sorted.map(clonePlan);
+async function refreshDietPlans() {
+  await loadDietPlans({ force: true });
+  return sortPlans(cachedDietPlans);
+}
+
+export async function listDietPlans(options = {}) {
+  const plans = await loadDietPlans(options);
+  const includeTemplates =
+    typeof options.includeTemplates === 'boolean' ? options.includeTemplates : true;
+  const filtered = includeTemplates
+    ? plans
+    : plans.filter((plan) => plan?.source !== 'template');
+  return sortPlans(filtered).map(clonePlan);
+}
+
+export async function listDietPlanTemplates() {
+  const plans = await loadDietPlans();
+  return sortPlans(plans.filter((plan) => plan?.source === 'template')).map(clonePlan);
 }
 
 export async function getDietPlanById(id) {
@@ -702,42 +671,55 @@ export async function getDietPlanById(id) {
     return null;
   }
 
-  const plans = await getDietPlans();
-  const found = plans.find((plan) => plan.id === id);
-  return found ? clonePlan(found) : null;
+  if (Array.isArray(cachedDietPlans)) {
+    const cached = cachedDietPlans.find((plan) => plan.id === id);
+    if (cached) {
+      return clonePlan(cached);
+    }
+  }
+
+  try {
+    const payload = await fetchJson(`/diet-plans/${encodeURIComponent(id)}`);
+    if (!payload?.data) {
+      return null;
+    }
+    await refreshDietPlans();
+    return clonePlan(withPlanDefaults(payload.data));
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export async function getActiveDietPlan() {
-  const plans = await getDietPlans();
+  const plans = await loadDietPlans();
   const active = plans.find((plan) => plan.isActive);
   return active ? clonePlan(active) : null;
 }
 
 export async function createDietPlan(plan) {
-  const plans = await getDietPlans();
-  const now = new Date().toISOString();
-  const basePlan = {
-    ...plan,
-    id: `diet_plan_${generateId()}`,
-    created_at: now,
-    updated_at: now,
-    source: plan?.source || 'custom',
+  const preparedPlan = {
+    ...(typeof plan === 'object' && plan !== null ? plan : {}),
+    source:
+      typeof plan?.source === 'string' && plan.source.length > 0
+        ? plan.source
+        : 'custom',
   };
 
-  const normalized = withPlanDefaults(basePlan, plans.length);
+  const payload = await fetchJson('/diet-plans', {
+    method: 'POST',
+    body: { plan: preparedPlan }
+  });
 
-  const nextPlans = normalized.isActive
-    ? plans.map((existing) =>
-        existing.isActive
-          ? { ...existing, isActive: false, updated_at: now }
-          : { ...existing },
-      )
-    : plans.map((existing) => ({ ...existing }));
+  const saved = payload?.data ? payload.data : null;
+  if (!saved) {
+    throw new Error('The server did not return the saved plan.');
+  }
 
-  const updated = [normalized, ...nextPlans];
-  cachedDietPlans = updated;
-  writePlansToLocalStorage(updated);
-  return clonePlan(normalized);
+  await refreshDietPlans();
+  return clonePlan(withPlanDefaults(saved));
 }
 
 export async function updateDietPlan(id, updates = {}) {
@@ -745,44 +727,18 @@ export async function updateDietPlan(id, updates = {}) {
     throw new Error('An id is required to update a diet plan.');
   }
 
-  const plans = await getDietPlans();
-  const index = plans.findIndex((plan) => plan.id === id);
-
-  if (index === -1) {
-    throw new Error('Diet plan not found.');
-  }
-
-  const now = new Date().toISOString();
-  const existing = plans[index];
-
-  const normalized = withPlanDefaults(
-    {
-      ...existing,
-      ...updates,
-      id: existing.id,
-      created_at: existing.created_at,
-      updated_at: now,
-      source: updates.source || existing.source,
-      isActive: typeof updates.isActive === 'boolean' ? updates.isActive : existing.isActive,
-    },
-    index,
-  );
-
-  const nextPlans = plans.map((plan) => {
-    if (plan.id === id) {
-      return normalized;
-    }
-
-    if (normalized.isActive && plan.isActive) {
-      return { ...plan, isActive: false, updated_at: now };
-    }
-
-    return { ...plan };
+  const payload = await fetchJson(`/diet-plans/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body: { plan: updates }
   });
 
-  cachedDietPlans = nextPlans;
-  writePlansToLocalStorage(nextPlans);
-  return clonePlan(normalized);
+  const saved = payload?.data ? payload.data : null;
+  if (!saved) {
+    throw new Error('The server did not return the updated plan.');
+  }
+
+  await refreshDietPlans();
+  return clonePlan(withPlanDefaults(saved));
 }
 
 export async function setActiveDietPlan(id) {
@@ -790,29 +746,24 @@ export async function setActiveDietPlan(id) {
     throw new Error('An id is required to set the active diet plan.');
   }
 
-  const plans = await getDietPlans();
-  const now = new Date().toISOString();
-  let found = false;
-
-  const nextPlans = plans.map((plan) => {
-    if (plan.id === id) {
-      found = true;
-      return { ...plan, isActive: true, updated_at: now };
-    }
-
-    if (plan.isActive) {
-      return { ...plan, isActive: false, updated_at: now };
-    }
-
-    return { ...plan };
+  const payload = await fetchJson(`/diet-plans/${encodeURIComponent(id)}/activate`, {
+    method: 'POST'
   });
 
-  if (!found) {
-    throw new Error('Diet plan not found.');
+  const saved = payload?.data ? payload.data : null;
+  if (!saved) {
+    throw new Error('The server did not return the active plan.');
   }
 
-  cachedDietPlans = nextPlans;
-  writePlansToLocalStorage(nextPlans);
-  const active = nextPlans.find((plan) => plan.id === id);
-  return active ? clonePlan(active) : null;
+  await refreshDietPlans();
+  return clonePlan(withPlanDefaults(saved));
+}
+
+export async function deleteDietPlan(id) {
+  if (!id) {
+    throw new Error('An id is required to delete a diet plan.');
+  }
+
+  await fetchJson(`/diet-plans/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  await refreshDietPlans();
 }

--- a/src/pages/Upload.jsx
+++ b/src/pages/Upload.jsx
@@ -79,15 +79,38 @@ export default function UploadPage() {
   const handleSaveMeal = async (mealData) => {
     setIsSaving(true);
     setError(null);
-    
+
     try {
       await Meal.create(mealData);
       navigate(createPageUrl("Dashboard"));
     } catch (error) {
-      setError("Failed to save meal. Please try again.");
       console.error("Save error:", error);
+
+      const fallback = "Failed to save meal.";
+      const uniqueMessages = new Set();
+      const parts = [fallback];
+
+      const appendMessage = (message) => {
+        if (typeof message !== "string") {
+          return;
+        }
+
+        const trimmed = message.trim();
+        if (!trimmed || uniqueMessages.has(trimmed) || trimmed === fallback) {
+          return;
+        }
+
+        uniqueMessages.add(trimmed);
+        parts.push(trimmed);
+      };
+
+      appendMessage(error?.message);
+      appendMessage(error?.payload?.error);
+      appendMessage(error?.payload?.details?.message);
+
+      setError(parts.join(" "));
     }
-    
+
     setIsSaving(false);
   };
 


### PR DESCRIPTION
## Summary
- add a shared JSONB serializer so Neon inserts and seeds use explicit casts instead of driver-specific helpers
- have meal and diet plan upserts return the persisted rows and reuse them in API responses to confirm database writes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e162aefbc48328928860487e1a5a68